### PR TITLE
Healthcheck timeout was too short on Docker for Mac

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,6 @@ VOLUME /data
 
 EXPOSE 2379 2380 4001 7001
 
-HEALTHCHECK --interval=5s --retries=2 --timeout=1s CMD ETCDCTL_API=3 /bin/etcdctl --endpoints http://127.0.0.1:2379 get ping | grep -q pong
+HEALTHCHECK --interval=5s --retries=3 --timeout=2s CMD ETCDCTL_API=3 /bin/etcdctl --endpoints http://127.0.0.1:2379 get ping | grep -q pong
 
 ENTRYPOINT ["/bin/run.sh"]


### PR DESCRIPTION
fixes appcelerator/amp#433

- timeout = 2 sec
- retries = 3

This is a workaround, the issue is really on Docker for Mac...
