### PR TITLE
Upstream 3.0.15

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM appcelerator/alpine:20160928
 
-ENV ETCD_VERSION 3.0.14
+ENV ETCD_VERSION 3.0.15
 RUN curl -L https://github.com/coreos/etcd/releases/download/v${ETCD_VERSION}/etcd-v${ETCD_VERSION}-linux-amd64.tar.gz -o etcd.tar.gz && \
     tar xzf etcd.tar.gz && \
     mv etcd-*/etcd /etcd-*/etcdctl /bin/ && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,6 @@ VOLUME /data
 
 EXPOSE 2379 2380 4001 7001
 
-HEALTHCHECK --interval=5s --retries=2 --timeout=1s CMD ETCDCTL_API=3 /bin/etcdctl --endpoints http://127.0.0.1:2379 get ping | grep -q pong
+HEALTHCHECK --interval=5s --retries=3 --timeout=2s CMD ETCDCTL_API=3 /bin/etcdctl --endpoints http://127.0.0.1:2379 get ping | grep -q pong
 
 ENTRYPOINT ["/bin/run.sh"]


### PR DESCRIPTION
- etcd 3.0.15
- healthcheck workaround for Docker for Mac (cherry pick from branch 3.1)