### PR TITLE
Temporary PR for #1462

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,6 @@ EXPOSE 2379 2380 4001 7001
 ENV MIN_SEEDS_COUNT 2
 ENV ETCDCTL_API 3
 
-#HEALTHCHECK --interval=5s --retries=3 --timeout=10s CMD ETCDCTL_API=3 /bin/etcdctl --endpoints=http://127.0.0.1:2379 get ping | grep -q pong
+HEALTHCHECK --interval=5s --retries=3 --timeout=10s CMD ETCDCTL_API=3 /bin/etcdctl --endpoints=http://127.0.0.1:2379 get ping | grep -q pong
 
 ENTRYPOINT ["/bin/run.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,8 @@ RUN curl -L https://github.com/coreos/etcd/releases/download/v${ETCD_VERSION}/et
     rm -rf etcd.tar.gz etcd-*
 
 COPY run.sh /bin/
+COPY healthcheck.sh /bin/
+RUN chmod 755 /bin/healthcheck.sh
 
 VOLUME /data
 
@@ -17,6 +19,6 @@ EXPOSE 2379 2380 4001 7001
 ENV MIN_SEEDS_COUNT 2
 ENV ETCDCTL_API 3
 
-HEALTHCHECK --interval=5s --retries=3 --timeout=10s CMD ETCDCTL_API=3 /bin/etcdctl --endpoints=http://127.0.0.1:2379 get ping | grep -q pong
+HEALTHCHECK --start-period=1s --interval=5s --retries=3 --timeout=10s CMD /bin/healthcheck.sh
 
 ENTRYPOINT ["/bin/run.sh"]

--- a/healthcheck.sh
+++ b/healthcheck.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+tips=$(dig +short tasks.$SERVICE_NAME)
+nbt=$(echo $tips | wc -w)
+
+# we do not have min seeds number yet
+# peacefully exit to allow swarm to add new node to DNS list (service.$SERVICE_NAME) 
+# see #1462
+[[ $nbt -lt ${MIN_SEEDS_COUNT} ]] && exit 0
+
+export ETCDCTL_API=3
+/bin/etcdctl --endpoints=http://127.0.0.1:2379 get ping | grep -q pong


### PR DESCRIPTION
Solves health check issue , where run.sh entrypoint waits for never happening update in service.$SERVICE_NAME DNS list. And health check always fails until we got all seeds in DNS list.

So it was basically dead lock.